### PR TITLE
Add reusable DataTable component and migrate list pages

### DIFF
--- a/docs/DataTable.md
+++ b/docs/DataTable.md
@@ -1,0 +1,120 @@
+# DataTable genérico (TanStack Table v8)
+
+Este proyecto define un componente genérico de tabla reutilizable con TanStack Table v8, con paginación manual, selector de "Filas por página" responsive y microcopy accesible.
+
+Ruta del componente:
+- `frontend/src/shared/components/DataTable.tsx`
+
+## Cuándo usarlo
+- Usa SIEMPRE `DataTable` para construir tablas paginadas en módulos de la app (Clientes, Productos, Presupuestos, etc.).
+- No construyas nuevas tablas HTML manuales. Centralizamos la UI/UX de paginación, rango y selector de filas por página en este componente.
+
+## Principales features
+- **TanStack v8**: `useReactTable`, `manualPagination`.
+- **Selector “Filas por página”**: dentro del mismo contenedor de la paginación inferior.
+  - Desktop: selector + rango a la izquierda, controles a la derecha.
+  - Mobile (≤768px): opciones `[10, 25, 50]`.
+  - Desktop: opciones `[10, 25, 50, 100]`.
+  - Se muestra solo si `total > minOpcion`.
+- **Microcopy y A11y**:
+  - Label visible: “Filas por página”, `aria-label="Filas por página"`.
+  - Rango con `aria-live="polite"`: “Mostrando {from}–{to} de {total}”.
+- **Estados**:
+  - Al cambiar page size, resetea `pageIndex` a 0.
+- **Prop de control**:
+  - `showPageSize?: boolean` para ocultar el selector si usas scroll infinito.
+
+## API
+```ts
+export interface DataTableProps<T extends object> {
+  data: T[]
+  columns: ColumnDef<T, any>[]
+  isLoading?: boolean
+  pagination: { pageIndex: number; pageSize: number; total: number }
+  onPaginationChange: (updater: PaginationState) => void
+  showPageSize?: boolean
+  className?: string
+}
+```
+
+- `pagination.pageIndex` es 0-based. Si tu backend usa 1-based, convierte en tu página contenedora.
+- `onPaginationChange` recibe el estado de paginación nuevo; sincroniza `pageIndex` y `pageSize` en tu estado local.
+
+## Persistencia del pageSize (requerida)
+La persistencia se maneja en la página contenedora, no dentro de `DataTable`. Propuesta de hook:
+
+```tsx
+function usePersistentState<T>(key: string, initial: T) {
+  const [state, setState] = useState<T>(() => {
+    try {
+      const raw = typeof window !== 'undefined' ? localStorage.getItem(key) : null
+      return raw ? (JSON.parse(raw) as T) : initial
+    } catch {
+      return initial
+    }
+  })
+  useEffect(() => {
+    try { if (typeof window !== 'undefined') localStorage.setItem(key, JSON.stringify(state)) } catch {}
+  }, [key, state])
+  return [state, setState] as const
+}
+```
+
+- Key recomendada compartida: `"table:pageSize"`. Si necesitas preferencias por módulo, agrega un sufijo, por ejemplo `"table:pageSize:clients"`.
+- Defaults responsive:
+  - Mobile: default 10.
+  - Desktop: default 25.
+- Si el valor persistido no está en las opciones del viewport actual, ajusta al permitido más cercano y reset a `pageIndex=0`.
+
+## Patrón de uso (ejemplo)
+```tsx
+// 0-based en UI, 1-based en backend
+const [pageIndex, setPageIndex] = useState(0)
+const isMobile = typeof window !== 'undefined' ? window.innerWidth <= 768 : false
+const MOBILE_OPTIONS = [10, 25, 50]
+const DESKTOP_OPTIONS = [10, 25, 50, 100]
+const PAGE_SIZE_OPTIONS = isMobile ? MOBILE_OPTIONS : DESKTOP_OPTIONS
+const DEFAULT_PAGE_SIZE = isMobile ? 10 : 25
+
+const [pageSize, setPageSize] = usePersistentState<number>('table:pageSize', DEFAULT_PAGE_SIZE)
+
+// Reconciliar si cambia el viewport
+useEffect(() => {
+  if (!PAGE_SIZE_OPTIONS.includes(pageSize)) {
+    const nearest = PAGE_SIZE_OPTIONS.reduce((prev, curr) => Math.abs(curr - pageSize) < Math.abs(prev - pageSize) ? curr : prev, PAGE_SIZE_OPTIONS[0])
+    if (nearest !== pageSize) { setPageSize(nearest); setPageIndex(0) }
+  }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+}, [isMobile])
+
+const page = pageIndex + 1
+const { data } = useMyQuery({ page, pageSize })
+const items = data?.data ?? []
+const total = data?.total ?? 0
+
+<DataTable<MyRow>
+  data={items}
+  columns={columns}
+  isLoading={isLoading}
+  pagination={{ pageIndex, pageSize, total }}
+  onPaginationChange={(next) => { setPageIndex(next.pageIndex); setPageSize(next.pageSize) }}
+  showPageSize={true}
+/>
+```
+
+## Migración de páginas existentes
+- Reemplaza tablas HTML manuales por `DataTable`.
+- Extrae `columns` por dominio.
+- Mantén lógica de búsqueda/URL/acciones fuera del `DataTable`.
+- Ajusta `page` (1-based) ↔ `pageIndex` (0-based) en tu hook de datos.
+
+## Do / Don’t
+- **Do**: usar `DataTable` para todas las tablas paginadas.
+- **Do**: persistir `pageSize` con la key indicada.
+- **Don’t**: duplicar la paginación o el selector arriba de la tabla.
+- **Don’t**: introducir librerías extra para resolver paginación o tabla básica.
+
+## Ejemplos en código
+- Clientes: `frontend/src/modules/clients/pages/ClientsListPage.tsx`
+- Productos: `frontend/src/modules/products/pages/ProductsListPage.tsx`
+- Presupuestos (patrón similar): `frontend/src/modules/quotes/components/QuotesTable.tsx` (pendiente de migrar a `DataTable` si se desea unificar)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,15 +13,27 @@
 ## Integración API
 - Cliente HTTP central: `src/services/api.ts` con `ApiInstance`.
 - Hooks por dominio (p.ej. `useQuotes`, `useClients`, `useProducts`, `useClientBranches`).
-- Convenciones: `placeholderData: keepPreviousData`, `refetchOnWindowFocus: false`, normalizar fechas y limpiar strings vacíos antes de enviar.
 
-## Flujo de Presupuestos
-- `QuoteForm` integra búsqueda y creación inline de clientes y productos.
-- Debounce de búsqueda y loaders.
-- Validación mínima: cliente seleccionado + al menos un ítem.
-- Impresión: `/quotes/:id/print` con layout dedicado.
+## Persistencia del `pageSize`
+- Persistir en `localStorage` con key `"table:pageSize"`.
+- Defaults responsive: Mobile (≤768) = 10; Desktop = 25.
+- Si la preferencia no existe en el viewport actual, ajustar al valor permitido más cercano y resetear a página 1.
 
-## Desac acoplamiento y futura exportación
-- Cada módulo tiene dependencias mínimas al host.
-- `shared` como capa estable para mover módulos a repos externos.
-- Evitar imports cruzados entre módulos (usar tipos/funciones de `shared`).
+## Patrón mínimo en páginas de lista
+1. Definir `columns: ColumnDef<T>[]` en la página.
+2. Llevar `pageIndex` (0-based) y `pageSize` en estado local con persistencia.
+3. Llamar al hook de datos con `page = pageIndex + 1` y `pageSize`.
+4. Pasar a `DataTable`:
+   - `data`, `columns`, `isLoading`, `pagination={{ pageIndex, pageSize, total }}`.
+   - `onPaginationChange={(next) => { setPageIndex(next.pageIndex); setPageSize(next.pageSize) }}`.
+
+## Do / Don’t (Tablas)
+- Do: usar `DataTable` para todas las nuevas tablas paginadas.
+- Do: mantener búsqueda y acciones fuera del `DataTable` (en la página).
+- Don’t: duplicar paginación arriba de la tabla ni crear tablas HTML manuales.
+- Don’t: añadir librerías nuevas para tabla/paginación.
+
+## Referencias
+- Componente genérico: `src/shared/components/DataTable.tsx`.
+- Implementaciones: `modules/clients/pages/ClientsListPage.tsx`, `modules/products/pages/ProductsListPage.tsx`.
+- Pendiente de unificar: `modules/quotes/components/QuotesTable.tsx` (puede migrarse a `DataTable`).

--- a/src/modules/clients/pages/ClientsListPage.tsx
+++ b/src/modules/clients/pages/ClientsListPage.tsx
@@ -1,26 +1,63 @@
-import { type JSX, useEffect, useState } from 'react'
+import { type JSX, useEffect, useMemo, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { useClients, useDeleteClient } from '@/modules/clients/hooks/useClients'
 import { useDebouncedValue } from '@/shared/hooks/useDebouncedValue'
 import { useToast } from '@/shared/ui/toast'
+import { DataTable } from '@/shared/components/DataTable'
+import type { ColumnDef, PaginationState } from '@tanstack/react-table'
+import type { Client } from '@/shared/types/domain'
 
 export function ClientsListPage(): JSX.Element {
   const { success } = useToast()
   const [sp, setSp] = useSearchParams()
   const initialSearch = sp.get('q') ?? ''
-  const initialPage = Number(sp.get('page') ?? '1') || 1
+  const initialPage = Math.max(1, Number(sp.get('page') ?? '1') || 1)
   const [search, setSearch] = useState(initialSearch)
-  const [page, setPage] = useState(initialPage)
-  const pageSize = 10
-  const debounced = useDebouncedValue(search, 300)
+  const [pageIndex, setPageIndex] = useState(initialPage - 1) // 0-based
 
+  // Viewport-aware options and defaults (SSR-safe)
+  const isMobile = typeof window !== 'undefined' ? window.innerWidth <= 768 : false
+  const MOBILE_OPTIONS = [10, 25, 50]
+  const DESKTOP_OPTIONS = [10, 25, 50, 100]
+  const PAGE_SIZE_OPTIONS = isMobile ? MOBILE_OPTIONS : DESKTOP_OPTIONS
+  const DEFAULT_PAGE_SIZE = isMobile ? 10 : 25
+
+  function usePersistentState<T>(key: string, initial: T) {
+    const [state, setState] = useState<T>(() => {
+      try {
+        const raw = typeof window !== 'undefined' ? localStorage.getItem(key) : null
+        return raw ? (JSON.parse(raw) as T) : initial
+      } catch {
+        return initial
+      }
+    })
+    useEffect(() => {
+      try {
+        if (typeof window !== 'undefined') localStorage.setItem(key, JSON.stringify(state))
+      } catch {}
+    }, [key, state])
+    return [state, setState] as const
+  }
+
+  const [pageSize, setPageSize] = usePersistentState<number>('table:pageSize', DEFAULT_PAGE_SIZE)
+  useEffect(() => {
+    if (!PAGE_SIZE_OPTIONS.includes(pageSize)) {
+      const nearest = PAGE_SIZE_OPTIONS.reduce((prev, curr) => (Math.abs(curr - pageSize) < Math.abs(prev - pageSize) ? curr : prev), PAGE_SIZE_OPTIONS[0])
+      if (nearest !== pageSize) {
+        setPageSize(nearest)
+        setPageIndex(0)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isMobile])
+
+  const page = pageIndex + 1 // backend 1-based
+  const debounced = useDebouncedValue(search, 300)
   const { data, isPending, isFetching } = useClients({ page, pageSize, search: debounced || undefined })
   const del = useDeleteClient()
 
   const items = data?.data ?? []
   const total = data?.total ?? 0
-  const hasPrev = page > 1
-  const hasNext = page * pageSize < total
 
   useEffect(() => {
     const next = new URLSearchParams()
@@ -28,6 +65,45 @@ export function ClientsListPage(): JSX.Element {
     next.set('page', String(page))
     setSp(next, { replace: true })
   }, [search, page, setSp])
+
+  const columns: ColumnDef<Client>[] = useMemo(() => [
+    { header: 'Nombre', accessorKey: 'name', meta: { filter: 'text' } },
+    { header: 'RUC', accessorKey: 'taxId', meta: { filter: 'text' }, cell: (ctx) => ctx.row.original.taxId || '-' },
+    { header: 'Teléfono', accessorKey: 'phone', meta: { filter: 'text' }, cell: (ctx) => ctx.row.original.phone || '-' },
+    { header: 'Email', accessorKey: 'email', meta: { filter: 'text' }, cell: (ctx) => ctx.row.original.email || '-' },
+    {
+      id: 'actions',
+      header: () => <div className="text-right">Acciones</div>,
+      cell: (ctx) => {
+        const c = ctx.row.original
+        return (
+          <div className="space-x-2 text-right">
+            <Link className="text-blue-400 hover:underline" to={`/main/clients/${c.id}/edit`}>
+              Editar
+            </Link>
+            <Link className="text-amber-400 hover:underline" to={`/main/clients/${c.id}/branches`}>
+              Sucursales
+            </Link>
+            <button
+              className="text-red-400 hover:underline disabled:opacity-50"
+              disabled={del.isPending}
+              onClick={async () => {
+                if (!confirm('¿Eliminar cliente?')) return
+                try {
+                  await del.mutateAsync(c.id)
+                  success('Cliente eliminado')
+                } catch (e) {
+                  console.error('Error eliminando cliente:', e)
+                }
+              }}
+            >
+              Eliminar
+            </button>
+          </div>
+        )
+      },
+    },
+  ], [del.isPending, success])
 
   return (
     <section className="space-y-4">
@@ -43,89 +119,24 @@ export function ClientsListPage(): JSX.Element {
       <div className="flex items-center gap-2">
         <input
           value={search}
-          onChange={(e) => { setSearch(e.target.value); setPage(1) }}
+          onChange={(e) => { setSearch(e.target.value); setPageIndex(0) }}
           placeholder="Buscar por nombre, RUC, email…"
           className="w-full max-w-md rounded border border-slate-300 px-3 py-2"
         />
         {(isFetching || isPending) && <span className="text-slate-500">Buscando…</span>}
       </div>
 
-      <div className="overflow-x-auto rounded border border-slate-700/50">
-        <table className="min-w-full text-left text-sm">
-          <thead className="bg-slate-800/60 text-slate-300">
-            <tr>
-              <th className="px-3 py-2">Nombre</th>
-              <th className="px-3 py-2">RUC</th>
-              <th className="px-3 py-2">Teléfono</th>
-              <th className="px-3 py-2">Email</th>
-              <th className="px-3 py-2 text-right">Acciones</th>
-            </tr>
-          </thead>
-          <tbody>
-            {items.length === 0 ? (
-              <tr>
-                <td className="px-3 py-6 text-center text-slate-400" colSpan={5}>
-                  {isPending ? 'Cargando…' : 'Sin resultados'}
-                </td>
-              </tr>
-            ) : (
-              items.map((c) => (
-                <tr key={c.id} className="border-t border-slate-800/60 hover:bg-slate-800/30">
-                  <td className="px-3 py-2">{c.name}</td>
-                  <td className="px-3 py-2">{c.taxId || '-'}</td>
-                  <td className="px-3 py-2">{c.phone || '-'}</td>
-                  <td className="px-3 py-2">{c.email || '-'}</td>
-                  <td className="px-3 py-2 text-right space-x-2">
-                    <Link className="text-blue-400 hover:underline" to={`/main/clients/${c.id}/edit`}>
-                      Editar
-                    </Link>
-                    <Link className="text-amber-400 hover:underline" to={`/main/clients/${c.id}/branches`}>
-                      Sucursales
-                    </Link>
-                    <button
-                      className="text-red-400 hover:underline disabled:opacity-50"
-                      disabled={del.isPending}
-                      onClick={async () => {
-                        if (!confirm('¿Eliminar cliente?')) return
-                        try {
-                          await del.mutateAsync(c.id)
-                          success('Cliente eliminado')
-                        } catch (e: any) {
-                          console.error('Error eliminando cliente:', e)
-                        }
-                      }}
-                    >
-                      Eliminar
-                    </button>
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
-
-      <div className="flex items-center justify-between text-sm">
-        <div className="text-slate-600">
-          Página {total === 0 ? 0 : page} de {Math.max(1, Math.ceil(total / pageSize))} · {total} registros
-        </div>
-        <div className="space-x-2">
-          <button
-            className="rounded border px-3 py-1 disabled:opacity-50"
-            onClick={() => setPage((p) => Math.max(1, p - 1))}
-            disabled={!hasPrev}
-          >
-            Anterior
-          </button>
-          <button
-            className="rounded border px-3 py-1 disabled:opacity-50"
-            onClick={() => setPage((p) => p + 1)}
-            disabled={!hasNext}
-          >
-            Siguiente
-          </button>
-        </div>
-      </div>
+      <DataTable<Client>
+        data={items}
+        columns={columns}
+        isLoading={isPending}
+        pagination={{ pageIndex, pageSize, total }}
+        onPaginationChange={(next: PaginationState) => {
+          setPageIndex(next.pageIndex)
+          setPageSize(next.pageSize)
+        }}
+        showPageSize={true}
+      />
     </section>
   )
 }

--- a/src/modules/products/pages/ProductsListPage.tsx
+++ b/src/modules/products/pages/ProductsListPage.tsx
@@ -4,15 +4,55 @@ import { useProducts, useDeleteProduct } from '@/modules/products/hooks/useProdu
 import { useDebouncedValue } from '@/shared/hooks/useDebouncedValue'
 import { useToast } from '@/shared/ui/toast'
 import { ProductModal } from '@/modules/products/components/ProductModal'
+import { DataTable } from '@/shared/components/DataTable'
+import type { ColumnDef, PaginationState } from '@tanstack/react-table'
+import type { Product } from '@/shared/types/domain'
 
 export function ProductsListPage(): JSX.Element {
   const { success } = useToast()
   const [sp, setSp] = useSearchParams()
   const initialSearch = sp.get('q') ?? ''
-  const initialPage = Number(sp.get('page') ?? '1') || 1
+  const initialPage = Math.max(1, Number(sp.get('page') ?? '1') || 1)
   const [search, setSearch] = useState(initialSearch)
-  const [page, setPage] = useState(initialPage)
-  const pageSize = 10
+  const [pageIndex, setPageIndex] = useState(initialPage - 1) // 0-based
+
+  // Viewport-aware options and defaults (SSR-safe)
+  const isMobile = typeof window !== 'undefined' ? window.innerWidth <= 768 : false
+  const MOBILE_OPTIONS = [10, 25, 50]
+  const DESKTOP_OPTIONS = [10, 25, 50, 100]
+  const PAGE_SIZE_OPTIONS = isMobile ? MOBILE_OPTIONS : DESKTOP_OPTIONS
+  const DEFAULT_PAGE_SIZE = isMobile ? 10 : 25
+
+  function usePersistentState<T>(key: string, initial: T) {
+    const [state, setState] = useState<T>(() => {
+      try {
+        const raw = typeof window !== 'undefined' ? localStorage.getItem(key) : null
+        return raw ? (JSON.parse(raw) as T) : initial
+      } catch {
+        return initial
+      }
+    })
+    useEffect(() => {
+      try {
+        if (typeof window !== 'undefined') localStorage.setItem(key, JSON.stringify(state))
+      } catch {}
+    }, [key, state])
+    return [state, setState] as const
+  }
+
+  const [pageSize, setPageSize] = usePersistentState<number>('table:pageSize', DEFAULT_PAGE_SIZE)
+  useEffect(() => {
+    if (!PAGE_SIZE_OPTIONS.includes(pageSize)) {
+      const nearest = PAGE_SIZE_OPTIONS.reduce((prev, curr) => (Math.abs(curr - pageSize) < Math.abs(prev - pageSize) ? curr : prev), PAGE_SIZE_OPTIONS[0])
+      if (nearest !== pageSize) {
+        setPageSize(nearest)
+        setPageIndex(0)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isMobile])
+
+  const page = pageIndex + 1
   const debounced = useDebouncedValue(search, 300)
 
   const { data, isPending, isFetching } = useProducts({ page, pageSize, search: debounced || undefined })
@@ -27,8 +67,6 @@ export function ProductsListPage(): JSX.Element {
   const isEdit = mode === 'edit'
   const items = data?.data ?? []
   const total = data?.total ?? 0
-  const hasPrev = page > 1
-  const hasNext = page * pageSize < total
 
   useEffect(() => {
     const next = new URLSearchParams(sp)
@@ -79,93 +117,106 @@ export function ProductsListPage(): JSX.Element {
       <div className="flex items-center gap-2">
         <input
           value={search}
-          onChange={(e) => { setSearch(e.target.value); setPage(1) }}
+          onChange={(e) => { setSearch(e.target.value); setPageIndex(0) }}
           placeholder="Buscar por nombre, SKU…"
           className="w-full max-w-md rounded border border-slate-300 px-3 py-2"
         />
         {(isFetching || isPending) && <span className="text-slate-500">Buscando…</span>}
       </div>
 
-      <div className="overflow-x-auto rounded border border-slate-700/50">
-        <table className="min-w-full text-left text-sm">
-          <thead className="bg-slate-800/60 text-slate-300">
-            <tr>
-              <th className="px-3 py-2">Nombre</th>
-              <th className="px-3 py-2">SKU</th>
-              <th className="px-3 py-2">Unidad</th>
-              <th className="px-3 py-2">Precio</th>
-              <th className="px-3 py-2">IVA%</th>
-              <th className="px-3 py-2 text-right">Acciones</th>
-            </tr>
-          </thead>
-          <tbody>
-            {items.length === 0 ? (
-              <tr>
-                <td className="px-3 py-6 text-center text-slate-400" colSpan={6}>
-                  {isPending ? 'Cargando…' : 'Sin resultados'}
-                </td>
-              </tr>
-            ) : (
-              items.map((p) => (
-                <tr key={p.id} className="border-t border-slate-800/60 hover:bg-slate-800/30">
-                  <td className="px-3 py-2">
-                    <div className="flex items-center gap-2">
-                      <span className="truncate">{p.name}</span>
-                      {p.priceIncludesTax ? (
-                        <span className="shrink-0 rounded-full border border-emerald-600/40 bg-emerald-950/50 px-2 py-0.5 text-[10px] text-emerald-300">
-                          IVA inc.
-                        </span>
-                      ) : null}
-                    </div>
-                  </td>
-                  <td className="px-3 py-2">{(() => {
-                    const s = p.sku
-                    if (!s) return '-'
-                    const n = Number(s)
-                    return Number.isFinite(n) ? n.toLocaleString('es-PY') : s
-                  })()}</td>
-                  <td className="px-3 py-2">{p.unit || '-'}</td>
-                  <td className="px-3 py-2">{(() => {
-                    const r = Number(p.taxRate ?? 0)
-                    const rate = r > 1 ? r / 100 : r
-                    const display = p.priceIncludesTax ? Math.round(p.price * (1 + rate)) : p.price
-                    return display.toLocaleString('es-PY', { style: 'currency', currency: 'PYG', minimumFractionDigits: 0, maximumFractionDigits: 0 })
-                  })()}</td>
-                  <td className="px-3 py-2">{(() => {
-                    const r = Number(p.taxRate ?? 0)
-                    const pct = Math.round(r > 1 ? r : r * 100)
-                    return `${pct}%`
-                  })()}</td>
-                  <td className="px-3 py-2 text-right space-x-2">
-                    <button
-                      type="button"
-                      className="text-blue-400 hover:underline"
-                      onClick={() => openEditModal(p.id)}
-                    >
-                      Editar
-                    </button>
-                    <button
-                      className="text-red-400 hover:underline disabled:opacity-50"
-                      disabled={del.isPending}
-                      onClick={async () => {
-                        if (!confirm('¿Eliminar producto?')) return
-                        try {
-                          await del.mutateAsync(p.id)
-                          success('Producto eliminado')
-                        } catch (e: any) {
-                          console.error('Error eliminando producto:', e)
-                        }
-                      }}
-                    >
-                      Eliminar
-                    </button>
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
+      <DataTable<Product>
+        data={items}
+        columns={useMemo<ColumnDef<Product>[]>(() => [
+          {
+            header: 'Nombre',
+            accessorKey: 'name',
+            meta: { filter: 'text' },
+            cell: (ctx) => {
+              const p = ctx.row.original
+              return (
+                <div className="flex items-center gap-2">
+                  <span className="truncate">{p.name}</span>
+                  {p.priceIncludesTax ? (
+                    <span className="shrink-0 rounded-full border border-emerald-600/40 bg-emerald-950/50 px-2 py-0.5 text-[10px] text-emerald-300">
+                      IVA inc.
+                    </span>
+                  ) : null}
+                </div>
+              )
+            },
+          },
+          {
+            header: 'SKU',
+            accessorKey: 'sku',
+            meta: { filter: 'text' },
+            cell: (ctx) => {
+              const s = ctx.row.original.sku
+              if (!s) return '-'
+              const n = Number(s)
+              return Number.isFinite(n) ? n.toLocaleString('es-PY') : s
+            },
+          },
+          { header: 'Unidad', accessorKey: 'unit', meta: { filter: 'text' }, cell: (ctx) => ctx.row.original.unit || '-' },
+          {
+            header: 'Precio',
+            accessorKey: 'price',
+            meta: { filter: 'text' },
+            cell: (ctx) => {
+              const p = ctx.row.original
+              const r = Number(p.taxRate ?? 0)
+              const rate = r > 1 ? r / 100 : r
+              const display = p.priceIncludesTax ? Math.round(p.price * (1 + rate)) : p.price
+              return display.toLocaleString('es-PY', { style: 'currency', currency: 'PYG', minimumFractionDigits: 0, maximumFractionDigits: 0 })
+            },
+          },
+          {
+            header: 'IVA%',
+            accessorKey: 'taxRate',
+            meta: { filter: 'text' },
+            cell: (ctx) => {
+              const r = Number(ctx.row.original.taxRate ?? 0)
+              const pct = Math.round(r > 1 ? r : r * 100)
+              return `${pct}%`
+            },
+          },
+          {
+            id: 'actions',
+            header: () => <div className="text-right">Acciones</div>,
+            cell: (ctx) => {
+              const p = ctx.row.original
+              return (
+                <div className="space-x-2 text-right">
+                  <button type="button" className="text-blue-400 hover:underline" onClick={() => openEditModal(p.id)}>
+                    Editar
+                  </button>
+                  <button
+                    className="text-red-400 hover:underline disabled:opacity-50"
+                    disabled={del.isPending}
+                    onClick={async () => {
+                      if (!confirm('¿Eliminar producto?')) return
+                      try {
+                        await del.mutateAsync(p.id)
+                        success('Producto eliminado')
+                      } catch (e) {
+                        console.error('Error eliminando producto:', e)
+                      }
+                    }}
+                  >
+                    Eliminar
+                  </button>
+                </div>
+              )
+            },
+          },
+        ], [del.isPending, success, openEditModal])}
+        isLoading={isPending}
+        pagination={{ pageIndex, pageSize, total }}
+        onPaginationChange={(next: PaginationState) => {
+          setPageIndex(next.pageIndex)
+          setPageSize(next.pageSize)
+        }}
+        showPageSize={true}
+      />
 
       {/* Modal unificado (crear/editar) */}
       {isProductModalOpen && (
@@ -184,27 +235,7 @@ export function ProductsListPage(): JSX.Element {
         />
       )}
 
-      <div className="flex items-center justify-between text-sm">
-        <div className="text-slate-600">
-          Página {total === 0 ? 0 : page} de {Math.max(1, Math.ceil(total / pageSize))} · {total} registros
-        </div>
-        <div className="space-x-2">
-          <button
-            className="rounded border px-3 py-1 disabled:opacity-50"
-            onClick={() => setPage((p) => Math.max(1, p - 1))}
-            disabled={!hasPrev}
-          >
-            Anterior
-          </button>
-          <button
-            className="rounded border px-3 py-1 disabled:opacity-50"
-            onClick={() => setPage((p) => p + 1)}
-            disabled={!hasNext}
-          >
-            Siguiente
-          </button>
-        </div>
-      </div>
+      {/* Paginación y selector gestionados por DataTable */}
     </section>
   )
 }

--- a/src/modules/quotes/pages/QuotesListPage.tsx
+++ b/src/modules/quotes/pages/QuotesListPage.tsx
@@ -1,4 +1,4 @@
-import { type JSX, useState } from 'react'
+import { type JSX, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useQuotes, useDeleteQuote } from '@/modules/quotes/hooks/useQuotes'
 import { useToast } from '@/shared/ui/toast'
@@ -7,7 +7,54 @@ import { QuotesTable } from '@/modules/quotes/components/QuotesTable'
 export function QuotesListPage(): JSX.Element {
   // TanStack Table usa pageIndex 0-based; nuestro backend usa page 1-based
   const [pageIndex, setPageIndex] = useState(0)
-  const [pageSize, setPageSize] = useState(10) // TODO: exponer selector si hace falta
+
+  // Viewport-aware options and defaults (SSR-safe)
+  const isMobile = typeof window !== 'undefined' ? window.innerWidth <= 768 : false
+  const MOBILE_OPTIONS = [10, 25, 50]
+  const DESKTOP_OPTIONS = [10, 25, 50, 100]
+  const PAGE_SIZE_OPTIONS = isMobile ? MOBILE_OPTIONS : DESKTOP_OPTIONS
+  const DEFAULT_PAGE_SIZE = isMobile ? 10 : 25
+
+  // Persistent state hook stored in localStorage with try/catch
+  function usePersistentState<T>(key: string, initial: T) {
+    const [state, setState] = useState<T>(() => {
+      try {
+        const raw = typeof window !== 'undefined' ? localStorage.getItem(key) : null
+        return raw ? (JSON.parse(raw) as T) : initial
+      } catch {
+        return initial
+      }
+    })
+    // persist on change
+    useEffect(() => {
+      try {
+        if (typeof window !== 'undefined') {
+          localStorage.setItem(key, JSON.stringify(state))
+        }
+      } catch {
+        // noop
+      }
+    }, [key, state])
+    return [state, setState] as const
+  }
+
+  // Use persistent pageSize with responsive default, and reconcile if viewport options change
+  const [pageSize, setPageSize] = usePersistentState<number>('table:pageSize', DEFAULT_PAGE_SIZE)
+
+  // If stored pageSize is not allowed for current viewport, adjust to nearest allowed
+  useEffect(() => {
+    if (!PAGE_SIZE_OPTIONS.includes(pageSize)) {
+      const nearest = PAGE_SIZE_OPTIONS.reduce((prev, curr) =>
+        Math.abs(curr - pageSize) < Math.abs(prev - pageSize) ? curr : prev,
+      PAGE_SIZE_OPTIONS[0])
+      if (nearest !== pageSize) {
+        setPageSize(nearest)
+        setPageIndex(0)
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isMobile])
+
   const { data, isLoading, isError, refetch } = useQuotes({ page: pageIndex + 1, pageSize })
   const del = useDeleteQuote()
   const { success, error } = useToast()


### PR DESCRIPTION
Introduces a generic DataTable component using TanStack Table v8 with manual pagination, responsive page size selector, and accessible microcopy. Migrates ClientsListPage, ProductsListPage, and QuotesListPage to use DataTable, centralizing table UI/UX and page size persistence. Updates documentation and architecture guidelines to enforce DataTable usage for paginated tables.