### PR TITLE
Add HR employees & payroll; support half-day

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -33,14 +33,7 @@
   --radius: 0.5rem;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
+
 
 html,
 body,

--- a/src/layouts/main-layout.tsx
+++ b/src/layouts/main-layout.tsx
@@ -291,6 +291,21 @@ export function MainLayout() {
                     {canViewHrCalendar ? (
                       <>
                         <NavLink
+                          to="/main/hr/employees"
+                          onClick={closeSidebarOnMobile}
+                          className={({ isActive }) => [
+                            'flex items-center gap-3 pl-8 pr-4 py-2 text-sm transition-colors',
+                            isActive ? 'bg-blue-600 text-white border-r-2 border-blue-400' : 'text-slate-300 hover:bg-slate-700 hover:text-white',
+                            sidebarOpen ? '' : 'md:pl-0 md:pr-0 md:justify-center md:gap-0',
+                          ].join(' ')}
+                        >
+                          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                            <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3z" />
+                          </svg>
+                          <span className={sidebarOpen ? '' : 'md:hidden'}>Personal</span>
+                        </NavLink>
+
+                        <NavLink
                           to="/main/hr/calendar"
                           onClick={closeSidebarOnMobile}
                           className={({ isActive }) => [
@@ -303,6 +318,21 @@ export function MainLayout() {
                             <path d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V4a2 2 0 00-2-2h-1V0h-2v2H9V0H7v2H6zm0 2h8v2H6V4zm0 4h8v8H6V8z" />
                           </svg>
                           <span className={sidebarOpen ? '' : 'md:hidden'}>Calendario</span>
+                        </NavLink>
+
+                        <NavLink
+                          to="/main/hr/payroll"
+                          onClick={closeSidebarOnMobile}
+                          className={({ isActive }) => [
+                            'flex items-center gap-3 pl-8 pr-4 py-2 text-sm transition-colors',
+                            isActive ? 'bg-blue-600 text-white border-r-2 border-blue-400' : 'text-slate-300 hover:bg-slate-700 hover:text-white',
+                            sidebarOpen ? '' : 'md:pl-0 md:pr-0 md:justify-center md:gap-0',
+                          ].join(' ')}
+                        >
+                          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                            <path d="M4 4a2 2 0 00-2 2v1h16V5a2 2 0 00-2-2H4zm14 3H2v9a2 2 0 002 2h12a2 2 0 002-2V7z M9 13a1 1 0 11-2 0 1 1 0 012 0zm3-3a1 1 0 11-2 0 1 1 0 012 0zm3 3a1 1 0 11-2 0 1 1 0 012 0z" />
+                          </svg>
+                          <span className={sidebarOpen ? '' : 'md:hidden'}>Liquidaciones</span>
                         </NavLink>
 
                         <NavLink

--- a/src/modules/hr/api/calendarApi.ts
+++ b/src/modules/hr/api/calendarApi.ts
@@ -9,8 +9,9 @@ export interface Employee {
   phone: string | null
   avatarUrl: string | null
   department: string | null
-  monthlySalary: number | null
-  defaultShiftStart: string | null
+  salaryType: 'MONTHLY' | 'WEEKLY' | 'DAILY'
+  salaryAmount: number | null
+  isActive: boolean
   defaultShiftEnd: string | null
   weeklyOvertimeHours: number
   weeklyAdvances: number
@@ -31,7 +32,7 @@ export interface EmployeeSchedule {
   clockIn: string | null
   clockOut: string | null
   overtimeMinutes: number
-  dayType: 'LABORAL' | 'AUSENTE' | 'LIBRE' | 'NO_LABORAL' | 'FERIADO'
+  dayType: 'LABORAL' | 'AUSENTE' | 'LIBRE' | 'NO_LABORAL' | 'FERIADO' | 'MEDIO_DIA'
   notes: string | null
   advances: EmployeeAdvance[]
 }
@@ -53,7 +54,7 @@ export interface WeekData {
 export interface ScheduleUpsertInput {
   clockIn?: string | null
   clockOut?: string | null
-  dayType: 'LABORAL' | 'AUSENTE' | 'LIBRE' | 'NO_LABORAL' | 'FERIADO'
+  dayType: 'LABORAL' | 'AUSENTE' | 'LIBRE' | 'NO_LABORAL' | 'FERIADO' | 'MEDIO_DIA'
   overtimeMinutes?: number
   advanceAmount?: number | null
   notes?: string | null
@@ -86,8 +87,7 @@ export async function upsertSchedule(
   })
 }
 
-export async function initializeWeekSchedules({ startDate, clockIn, clockOut }: InitializeWeekInput): Promise<{ ok: boolean; updatedSchedules: number }>
-{
+export async function initializeWeekSchedules({ startDate, clockIn, clockOut }: InitializeWeekInput): Promise<{ ok: boolean; updatedSchedules: number }> {
   return ApiInstance.post<{ ok: boolean; updatedSchedules: number }>(`/hr/calendar/week/initialize`, {
     data: {
       startDate,
@@ -103,7 +103,7 @@ export interface ReportFilters {
   endDate: string
   employeeId?: string
   department?: string
-  dayType?: 'LABORAL' | 'AUSENTE' | 'LIBRE' | 'NO_LABORAL' | 'FERIADO'
+  dayType?: 'LABORAL' | 'AUSENTE' | 'LIBRE' | 'NO_LABORAL' | 'FERIADO' | 'MEDIO_DIA'
 }
 
 export interface ReportStats {
@@ -142,7 +142,7 @@ export async function getReportData(filters: ReportFilters): Promise<ReportData>
   const params = new URLSearchParams()
   params.append('startDate', filters.startDate)
   params.append('endDate', filters.endDate)
-  
+
   if (filters.employeeId) params.append('employeeId', filters.employeeId)
   if (filters.department && filters.department !== 'all') params.append('department', filters.department)
   if (filters.dayType) params.append('dayType', filters.dayType)

--- a/src/modules/hr/api/employeeApi.ts
+++ b/src/modules/hr/api/employeeApi.ts
@@ -1,0 +1,44 @@
+import { ApiInstance } from '@/services/api'
+import type { Employee } from './calendarApi'
+
+export interface CreateEmployeeInput {
+    firstName: string
+    lastName: string
+    email?: string
+    phone?: string
+    department?: string
+    salaryType: 'MONTHLY' | 'WEEKLY' | 'DAILY'
+    salaryAmount?: number | null
+    defaultShiftStart?: string | null
+    defaultShiftEnd?: string | null
+}
+
+export type UpdateEmployeeInput = Partial<CreateEmployeeInput>
+
+export async function listEmployees(): Promise<Employee[]> {
+    return ApiInstance.get<Employee[]>('/hr/employees')
+}
+
+export async function getEmployee(id: string): Promise<Employee> {
+    return ApiInstance.get<Employee>(`/hr/employees/${id}`)
+}
+
+export async function createEmployee(data: CreateEmployeeInput): Promise<Employee> {
+    return ApiInstance.post<Employee>('/hr/employees', {
+        data,
+        headers: { 'Content-Type': 'application/json' },
+    })
+}
+
+export async function updateEmployee(id: string, data: UpdateEmployeeInput): Promise<Employee> {
+    return ApiInstance.put<Employee>(`/hr/employees/${id}`, {
+        data,
+        headers: { 'Content-Type': 'application/json' },
+    })
+}
+
+export async function toggleEmployeeStatus(id: string): Promise<{ ok: boolean; isActive: boolean }> {
+    return ApiInstance.put<{ ok: boolean; isActive: boolean }>(`/hr/employees/${id}/toggle-status`, {
+        headers: { 'Content-Type': 'application/json' },
+    })
+}

--- a/src/modules/hr/api/payrollApi.ts
+++ b/src/modules/hr/api/payrollApi.ts
@@ -1,0 +1,80 @@
+import { ApiInstance } from '@/services/api'
+
+export interface PayrollPreviewQuery {
+    employeeId: string
+    startDate: string
+    endDate: string
+}
+
+export interface PayrollRequest {
+    employeeId: string
+    startDate: string
+    endDate: string
+}
+
+export interface PayrollPreviewResponse {
+    employee: {
+        id: string
+        name: string
+        salaryType: string
+        salaryAmount: number
+        dailyRate: number
+        hourlyRate: number
+    }
+    period: {
+        startDate: string
+        endDate: string
+    }
+    daysIncluded: Array<{
+        date: string
+        type: string
+        overtimeMinutes: number
+        advance: number
+    }>
+    orphanAdvances: Array<{
+        id: string
+        amount: number
+        date: string
+    }>
+    summary: {
+        totalDaysWorked: number
+        totalOvertimeHours: number
+        baseAmount: number
+        overtimeAmount: number
+        advancesAmount: number
+        totalAmount: number
+    }
+}
+
+export interface EmployeePayment {
+    id: string
+    tenantId: string
+    employeeId: string
+    startDate: string
+    endDate: string
+    paymentDate: string
+    totalDaysWorked: string | number
+    totalOvertimeHours: string | number
+    baseAmount: string | number
+    overtimeAmount: string | number
+    advancesAmount: string | number
+    totalAmount: string | number
+    receiptNumber?: string
+    notes?: string
+    createdAt: string
+    updatedAt: string
+}
+
+export const payrollApi = {
+    getPreview: async (params: PayrollPreviewQuery): Promise<PayrollPreviewResponse> => {
+        return ApiInstance.get<PayrollPreviewResponse>('/hr/payroll/preview', { params })
+    },
+
+    execute: async (data: PayrollRequest): Promise<{ ok: boolean; payment: EmployeePayment }> => {
+        return ApiInstance.post<{ ok: boolean; payment: EmployeePayment }>('/hr/payroll/execute', { data })
+    },
+
+    getHistory: async (employeeId: string): Promise<EmployeePayment[]> => {
+        return ApiInstance.get<EmployeePayment[]>(`/hr/payroll/history/${employeeId}`)
+    }
+}

--- a/src/modules/hr/calendar/hooks/useScheduleClipboard.ts
+++ b/src/modules/hr/calendar/hooks/useScheduleClipboard.ts
@@ -5,7 +5,7 @@ export interface ClipboardSchedule {
   clockOut?: string
   advance?: number
   overtimeHours?: number
-  dayType?: 'laboral' | 'ausente' | 'libre' | 'no-laboral' | 'feriado'
+  dayType?: 'laboral' | 'ausente' | 'libre' | 'no-laboral' | 'feriado' | 'medio-dia'
 }
 
 export function useScheduleClipboard() {

--- a/src/modules/hr/components/DayCell.tsx
+++ b/src/modules/hr/components/DayCell.tsx
@@ -4,7 +4,7 @@ import { MdAccessTime } from 'react-icons/md'
 import { BiLogIn, BiLogOut } from 'react-icons/bi'
 import { PiCurrencyCircleDollarFill } from 'react-icons/pi'
 
-export type DayType = 'laboral' | 'ausente' | 'libre' | 'no-laboral' | 'feriado'
+export type DayType = 'laboral' | 'ausente' | 'libre' | 'no-laboral' | 'feriado' | 'medio-dia'
 
 export interface DayCellProps {
   /** Hora de entrada en formato HH:MM (ej: "09:00") */
@@ -30,6 +30,11 @@ const dayTypeConfig: Record<DayType, { bg: string; border: string; text: string 
     bg: 'bg-green-50',
     border: 'border-green-200',
     text: 'text-green-900',
+  },
+  'medio-dia': {
+    bg: 'bg-teal-50',
+    border: 'border-teal-200',
+    text: 'text-teal-900',
   },
   ausente: {
     bg: 'bg-[#f8d7da]',
@@ -66,7 +71,7 @@ export function DayCell(props: DayCellProps): JSX.Element {
   } = props
 
   const config = dayTypeConfig[dayType]
-  const showContent = dayType === 'laboral' && (clockIn || clockOut)
+  const showContent = (dayType === 'laboral' || dayType === 'medio-dia') && (clockIn || clockOut)
   const isToday = date ? isSameDay(date, new Date()) : false
 
   const combinedClassName = [
@@ -96,6 +101,7 @@ export function DayCell(props: DayCellProps): JSX.Element {
       ) : (
         <div className="flex h-full items-center justify-center">
           <span className="text-[10px] font-medium uppercase opacity-60">
+            {dayType === 'medio-dia' && 'Medio Día'}
             {dayType === 'ausente' && 'Ausente'}
             {dayType === 'libre' && 'Libre'}
             {dayType === 'no-laboral' && 'No Laboral'}

--- a/src/modules/hr/components/PayrollReceiptPrint.tsx
+++ b/src/modules/hr/components/PayrollReceiptPrint.tsx
@@ -1,0 +1,155 @@
+import { forwardRef } from 'react'
+import logo from '@/assets/logo.png'
+import type { EmployeePayment } from '../api/payrollApi'
+import { formatCurrency } from '@/shared/utils/format'
+
+export interface PayrollReceiptPrintProps {
+    payment: EmployeePayment
+    employee: { firstName: string, lastName: string, document?: string }
+    orgLogoUrl?: string | null
+    orgRuc?: string | null
+    orgName?: string | null
+}
+
+export const PayrollReceiptPrint = forwardRef<HTMLDivElement, PayrollReceiptPrintProps>(function PayrollReceiptPrint(
+    { payment, employee, orgLogoUrl, orgRuc, orgName },
+    ref
+) {
+    const formatDateUpper = (dateString: string) => {
+        const d = new Date(dateString)
+        const day = String(d.getDate()).padStart(2, '0')
+        const month = d.toLocaleString('es-PY', { month: 'long' }).toUpperCase()
+        const year = String(d.getFullYear())
+        return `${day} DE ${month} DE ${year}`
+    }
+
+    return (
+        <div
+            ref={ref}
+            className="mx-auto w-[210mm] max-w-full bg-white p-8 shadow print:shadow-none border border-[#cbd5e1] text-black"
+        >
+            {/* Encabezado */}
+            <div className="flex items-start justify-between border-b pb-4 mb-6 border-black">
+                <div className="flex items-center gap-4">
+                    <img
+                        src={orgLogoUrl || (logo as any)}
+                        alt="Logo"
+                        className="h-20 w-48 object-contain"
+                        crossOrigin="anonymous"
+                        referrerPolicy="no-referrer"
+                    />
+                </div>
+                <div className="text-right">
+                    <div className="text-2xl font-black tracking-wide text-black uppercase">
+                        Recibo de Salario
+                    </div>
+                    <div className="mt-2 text-lg font-bold">
+                        N° {payment.receiptNumber || payment.id.slice(0, 8).toUpperCase()}
+                    </div>
+                    <div className="text-sm font-semibold mt-1">
+                        Fecha Emisión: {formatDateUpper(payment.paymentDate)}
+                    </div>
+                    {orgRuc && (
+                        <div className="mt-1 text-xs font-medium text-gray-700">
+                            {orgName} | RUC: {orgRuc}
+                        </div>
+                    )}
+                </div>
+            </div>
+
+            {/* Datos del Empleado y Periodo */}
+            <div className="grid grid-cols-2 gap-4 mb-6">
+                <div className="border border-black p-3 rounded-sm">
+                    <div className="text-xs font-bold uppercase mb-1 border-b border-gray-300 pb-1">Datos del Empleado</div>
+                    <div className="text-lg font-bold">
+                        {employee.firstName} {employee.lastName}
+                    </div>
+                    {employee.document && (
+                        <div className="text-sm">Documento: {employee.document}</div>
+                    )}
+                </div>
+                <div className="border border-black p-3 rounded-sm">
+                    <div className="text-xs font-bold uppercase mb-1 border-b border-gray-300 pb-1">Periodo Liquidado</div>
+                    <div className="text-sm font-medium mt-2">
+                        Desde: <span className="font-bold">{formatDateUpper(payment.startDate)}</span>
+                    </div>
+                    <div className="text-sm font-medium">
+                        Hasta: <span className="font-bold">{formatDateUpper(payment.endDate)}</span>
+                    </div>
+                </div>
+            </div>
+
+            {/* Detalle de Liquidación */}
+            <div className="border border-black rounded-sm overflow-hidden mb-8">
+                <table className="w-full text-sm border-collapse">
+                    <thead className="bg-gray-100 border-b border-black">
+                        <tr>
+                            <th className="px-4 py-2 text-left border-r border-black font-bold uppercase">Concepto</th>
+                            <th className="px-4 py-2 text-right border-r border-black font-bold uppercase w-32">Cant.</th>
+                            <th className="px-4 py-2 text-right font-bold uppercase w-40">Monto</th>
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-300">
+                        {/* Salario Base */}
+                        <tr>
+                            <td className="px-4 py-3 border-r border-black">Salario (Días trabajados)</td>
+                            <td className="px-4 py-3 text-right border-r border-black">{payment.totalDaysWorked} días</td>
+                            <td className="px-4 py-3 text-right">{formatCurrency(Number(payment.baseAmount))}</td>
+                        </tr>
+                        {/* Horas Extras */}
+                        {Number(payment.totalOvertimeHours) > 0 && (
+                            <tr>
+                                <td className="px-4 py-3 border-r border-black">Horas Extras (50%)</td>
+                                <td className="px-4 py-3 text-right border-r border-black">{payment.totalOvertimeHours} hrs</td>
+                                <td className="px-4 py-3 text-right">{formatCurrency(Number(payment.overtimeAmount))}</td>
+                            </tr>
+                        )}
+                        {/* Descuentos (Adelantos) */}
+                        {Number(payment.advancesAmount) > 0 && (
+                            <tr>
+                                <td className="px-4 py-3 border-r border-black text-red-600 font-medium">Otros Descuentos / Vales / Adelantos</td>
+                                <td className="px-4 py-3 text-right border-r border-black"></td>
+                                <td className="px-4 py-3 text-right text-red-600 font-medium">-{formatCurrency(Number(payment.advancesAmount))}</td>
+                            </tr>
+                        )}
+
+                        {/* Relleno para que la tabla tenga mejor altura */}
+                        <tr className="h-16">
+                            <td className="border-r border-black"></td>
+                            <td className="border-r border-black"></td>
+                            <td></td>
+                        </tr>
+                    </tbody>
+                    <tfoot className="border-t border-black bg-gray-50">
+                        <tr>
+                            <td colSpan={2} className="px-4 py-3 text-right border-r border-black font-bold uppercase text-lg">
+                                Total a Cobrar (Neto)
+                            </td>
+                            <td className="px-4 py-3 text-right font-bold text-lg">
+                                {formatCurrency(Number(payment.totalAmount))}
+                            </td>
+                        </tr>
+                    </tfoot>
+                </table>
+            </div>
+
+            {/* Firmas */}
+            <div className="mt-16 pt-8 grid grid-cols-2 gap-8 text-center text-sm">
+                <div>
+                    <div className="mx-auto w-48 border-t border-black pt-2">
+                        Firma del Empleador
+                    </div>
+                </div>
+                <div>
+                    <div className="mx-auto w-48 border-t border-black pt-2">
+                        Recibí Conforme (Firma del Empleado)
+                    </div>
+                </div>
+            </div>
+
+            <div className="mt-12 text-center text-xs text-gray-400">
+                Documento generado por Kusystem - ID: {payment.id}
+            </div>
+        </div>
+    )
+})

--- a/src/modules/hr/module.ts
+++ b/src/modules/hr/module.ts
@@ -2,6 +2,9 @@ import { createElement, type ReactElement } from 'react'
 import type { ModuleDescriptor } from '@/shared/types/module'
 import { CalendarPage } from './pages/CalendarPage'
 import { ReportsPage } from './pages/ReportsPage'
+import { EmployeesListPage } from './pages/EmployeesListPage'
+import { EmployeeFormPage } from './pages/EmployeeFormPage'
+import { PayrollPage } from './pages/PayrollPage'
 
 function el(c: any): ReactElement {
   return createElement(c)
@@ -12,9 +15,14 @@ export const hrModule: ModuleDescriptor = {
   routes: [
     { path: 'hr/calendar', element: el(CalendarPage), requiredPermission: 'hr-calendar:view' },
     { path: 'hr/reports', element: el(ReportsPage), requiredPermission: 'hr-calendar:view' },
+    { path: 'hr/employees', element: el(EmployeesListPage), requiredPermission: 'hr-calendar:view' },
+    { path: 'hr/employees/:id', element: el(EmployeeFormPage), requiredPermission: 'hr-calendar:view' },
+    { path: 'hr/payroll', element: el(PayrollPage), requiredPermission: 'hr-calendar:view' },
   ],
   nav: [
+    { label: 'Personal', to: '/main/hr/employees', requiredPermission: 'hr-calendar:view' },
     { label: 'Calendario RRHH', to: '/main/hr/calendar', requiredPermission: 'hr-calendar:view' },
+    { label: 'Liquidaciones', to: '/main/hr/payroll', requiredPermission: 'hr-calendar:view' },
     { label: 'Reportes RRHH', to: '/main/hr/reports', requiredPermission: 'hr-calendar:view' },
   ],
 }

--- a/src/modules/hr/pages/EmployeeFormPage.tsx
+++ b/src/modules/hr/pages/EmployeeFormPage.tsx
@@ -1,0 +1,239 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useNavigate, useParams, Link } from 'react-router-dom'
+import { useState, useEffect } from 'react'
+import { getEmployee, createEmployee, updateEmployee } from '../api/employeeApi'
+
+export function EmployeeFormPage() {
+    const { id } = useParams<{ id: string }>()
+    const isNew = !id || id === 'new'
+    const navigate = useNavigate()
+    const qc = useQueryClient()
+
+    const [form, setForm] = useState({
+        firstName: '',
+        lastName: '',
+        email: '',
+        phone: '',
+        department: '',
+        salaryType: 'MONTHLY' as 'MONTHLY' | 'WEEKLY' | 'DAILY',
+        salaryAmount: '',
+        defaultShiftEnd: '',
+    })
+
+    const [errorMsg, setErrorMsg] = useState('')
+
+    const { data: employee, isLoading: isLoadingEmployee } = useQuery({
+        queryKey: ['hr-employee', id],
+        queryFn: () => getEmployee(id!),
+        enabled: !isNew,
+    })
+
+    useEffect(() => {
+        if (employee && !isNew) {
+            setForm({
+                firstName: employee.firstName,
+                lastName: employee.lastName,
+                email: employee.email || '',
+                phone: employee.phone || '',
+                department: employee.department || '',
+                salaryType: employee.salaryType,
+                salaryAmount: employee.salaryAmount ? String(employee.salaryAmount) : '',
+                defaultShiftEnd: employee.defaultShiftEnd || '',
+            })
+        }
+    }, [employee, isNew])
+
+    const saveMutation = useMutation({
+        mutationFn: (data: any) => isNew ? createEmployee(data) : updateEmployee(id!, data),
+        onSuccess: () => {
+            qc.invalidateQueries({ queryKey: ['hr-employees'] })
+            qc.invalidateQueries({ queryKey: ['hr-employee', id] })
+            navigate('/main/hr/employees')
+        },
+        onError: (err: any) => {
+            setErrorMsg(err?.response?.data?.error || err.message || 'Error al guardar el empleado')
+        }
+    })
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault()
+        setErrorMsg('')
+
+        if (!form.firstName.trim() || !form.lastName.trim()) {
+            setErrorMsg('Nombres y Apellidos son obligatorios')
+            return
+        }
+
+        const payload = {
+            ...form,
+            salaryAmount: form.salaryAmount ? Number(form.salaryAmount) : null,
+            email: form.email || null,
+            phone: form.phone || null,
+            department: form.department || null,
+            defaultShiftEnd: form.defaultShiftEnd || null,
+        }
+
+        saveMutation.mutate(payload)
+    }
+
+    if (!isNew && isLoadingEmployee) return <div className="p-6">Cargando datos del empleado...</div>
+
+    return (
+        <div className="p-4 md:p-6 max-w-4xl mx-auto space-y-6">
+            <div className="flex items-center gap-4">
+                <Link to="/main/hr/employees" className="text-slate-400 hover:text-white transition-colors">
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                </Link>
+                <div>
+                    <h1 className="text-2xl font-bold">{isNew ? 'Nuevo Empleado' : 'Editar Empleado'}</h1>
+                    <p className="text-slate-400 text-sm">Completa la información personal y las condiciones laborales</p>
+                </div>
+            </div>
+
+            <div className="bg-slate-900 border border-slate-800 rounded-xl p-6">
+                {errorMsg && (
+                    <div className="mb-6 p-4 bg-red-500/10 border border-red-500/50 rounded-lg text-red-400 text-sm">
+                        {errorMsg}
+                    </div>
+                )}
+
+                <form onSubmit={handleSubmit} className="space-y-6">
+                    <h3 className="text-lg font-medium border-b border-slate-800 pb-2">Información Personal</h3>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label className="block text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">
+                                Nombres <span className="text-red-500">*</span>
+                            </label>
+                            <input
+                                type="text"
+                                required
+                                value={form.firstName}
+                                onChange={e => setForm({ ...form, firstName: e.target.value })}
+                                className="w-full bg-slate-950 border border-slate-800 rounded px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500"
+                            />
+                        </div>
+                        <div>
+                            <label className="block text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">
+                                Apellidos <span className="text-red-500">*</span>
+                            </label>
+                            <input
+                                type="text"
+                                required
+                                value={form.lastName}
+                                onChange={e => setForm({ ...form, lastName: e.target.value })}
+                                className="w-full bg-slate-950 border border-slate-800 rounded px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500"
+                            />
+                        </div>
+                        <div>
+                            <label className="block text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">
+                                Email
+                            </label>
+                            <input
+                                type="email"
+                                value={form.email}
+                                onChange={e => setForm({ ...form, email: e.target.value })}
+                                className="w-full bg-slate-950 border border-slate-800 rounded px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500"
+                            />
+                        </div>
+                        <div>
+                            <label className="block text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">
+                                Teléfono
+                            </label>
+                            <input
+                                type="text"
+                                value={form.phone}
+                                onChange={e => setForm({ ...form, phone: e.target.value })}
+                                className="w-full bg-slate-950 border border-slate-800 rounded px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500"
+                            />
+                        </div>
+                    </div>
+
+                    <h3 className="text-lg font-medium border-b border-slate-800 pb-2 pt-4">Condiciones Laborales</h3>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label className="block text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">
+                                Departamento
+                            </label>
+                            <input
+                                type="text"
+                                value={form.department}
+                                onChange={e => setForm({ ...form, department: e.target.value })}
+                                className="w-full bg-slate-950 border border-slate-800 rounded px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500"
+                                placeholder="Ej. Ventas, Taller, Administración"
+                            />
+                        </div>
+                        <div className="col-span-1 md:col-span-2 grid grid-cols-2 gap-4">
+                            <div>
+                                <label className="block text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">
+                                    Tipo de Sueldo <span className="text-red-500">*</span>
+                                </label>
+                                <select
+                                    value={form.salaryType}
+                                    onChange={e => setForm({ ...form, salaryType: e.target.value as any })}
+                                    className="w-full bg-slate-950 border border-slate-800 rounded px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500"
+                                >
+                                    <option value="MONTHLY">Fijo Mensual</option>
+                                    <option value="WEEKLY">Fijo Semanal</option>
+                                    <option value="DAILY">Pago por Día Trabajado</option>
+                                </select>
+                            </div>
+                            <div>
+                                <label className="block text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">
+                                    Monto {form.salaryType === 'MONTHLY' ? '(Mensual)' : form.salaryType === 'WEEKLY' ? '(Semanal)' : '(Diario)'}
+                                </label>
+                                <div className="relative">
+                                    <span className="absolute left-3 top-2 text-slate-500 text-sm">₲</span>
+                                    <input
+                                        type="text"
+                                        inputMode="numeric"
+                                        value={form.salaryAmount ? Number(form.salaryAmount).toLocaleString('es-PY') : ''}
+                                        onChange={e => {
+                                            const rawValue = e.target.value.replace(/\D/g, '')
+                                            setForm({ ...form, salaryAmount: rawValue })
+                                        }}
+                                        className="w-full bg-slate-950 border border-slate-800 rounded pl-8 pr-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500"
+                                        placeholder="Opcional"
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <h3 className="text-lg font-medium border-b border-slate-800 pb-2 pt-4">Horario por Defecto (Opcional)</h3>
+                    <p className="text-xs text-slate-400 -mt-2 mb-4">Se usará para autocompletar el calendario de asistencia en RRHH.</p>
+                    <div className="grid grid-cols-2 max-w-sm gap-4">
+                        <div>
+                            <label className="block text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">
+                                Hora de Salida
+                            </label>
+                            <input
+                                type="time"
+                                value={form.defaultShiftEnd}
+                                onChange={e => setForm({ ...form, defaultShiftEnd: e.target.value })}
+                                className="w-full bg-slate-950 border border-slate-800 rounded px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500"
+                            />
+                        </div>
+                    </div>
+
+                    <div className="pt-6 border-t border-slate-800 flex justify-end gap-3">
+                        <Link
+                            to="/main/hr/employees"
+                            className="px-4 py-2 border border-slate-700 hover:bg-slate-800 rounded text-slate-300 transition-colors font-medium text-sm"
+                        >
+                            Cancelar
+                        </Link>
+                        <button
+                            type="submit"
+                            disabled={saveMutation.isPending}
+                            className="bg-blue-600 hover:bg-blue-500 text-white px-6 py-2 rounded font-medium disabled:opacity-50 transition-colors text-sm"
+                        >
+                            {saveMutation.isPending ? 'Guardando...' : 'Guardar Empleado'}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    )
+}

--- a/src/modules/hr/pages/EmployeesListPage.tsx
+++ b/src/modules/hr/pages/EmployeesListPage.tsx
@@ -1,0 +1,172 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Link, useNavigate } from 'react-router-dom'
+import { useState } from 'react'
+import { listEmployees, toggleEmployeeStatus } from '../api/employeeApi'
+
+export function EmployeesListPage() {
+    const qc = useQueryClient()
+    const navigate = useNavigate()
+    const [showInactive, setShowInactive] = useState(false)
+    const [searchTerm, setSearchTerm] = useState('')
+
+    const { data: employees = [], isLoading, isError } = useQuery({
+        queryKey: ['hr-employees'],
+        queryFn: listEmployees,
+    })
+
+    const toggleStatus = useMutation({
+        mutationFn: toggleEmployeeStatus,
+        onSuccess: () => {
+            qc.invalidateQueries({ queryKey: ['hr-employees'] })
+        },
+    })
+
+    if (isLoading) return <div className="p-6">Cargando personal...</div>
+    if (isError) return <div className="p-6 text-red-500">Error al cargar listado de personal</div>
+
+    const filteredEmployees = employees.filter((emp) => {
+        if (!showInactive && !emp.isActive) return false
+        if (searchTerm) {
+            const s = searchTerm.toLowerCase()
+            if (!emp.name.toLowerCase().includes(s) &&
+                !(emp.department || '').toLowerCase().includes(s) &&
+                !(emp.email || '').toLowerCase().includes(s)) {
+                return false
+            }
+        }
+        return true
+    })
+
+    return (
+        <div className="p-4 md:p-6 max-w-7xl mx-auto space-y-6">
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                <div>
+                    <h1 className="text-2xl font-bold">Personal</h1>
+                    <p className="text-slate-400 text-sm">Gestiona la nómina de empleados y sus esquemas salariales</p>
+                </div>
+                <Link
+                    to="/main/hr/employees/new"
+                    className="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded-lg font-medium transition-colors text-center"
+                >
+                    Nuevo Empleado
+                </Link>
+            </div>
+
+            <div className="bg-slate-900 border border-slate-800 rounded-xl p-4 flex flex-col sm:flex-row gap-4 justify-between items-center">
+                <div className="w-full sm:max-w-xs relative">
+                    <input
+                        type="text"
+                        placeholder="Buscar por nombre, email, depto..."
+                        value={searchTerm}
+                        onChange={(e) => setSearchTerm(e.target.value)}
+                        className="w-full bg-slate-950 border border-slate-800 rounded px-3 py-2 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-blue-500"
+                    />
+                </div>
+                <label className="flex items-center gap-2 text-sm text-slate-300 cursor-pointer">
+                    <input
+                        type="checkbox"
+                        checked={showInactive}
+                        onChange={(e) => setShowInactive(e.target.checked)}
+                        className="rounded border-slate-700 bg-slate-800 text-blue-600 focus:ring-blue-600 h-4 w-4"
+                    />
+                    Mostrar Inactivos
+                </label>
+            </div>
+
+            <div className="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
+                <div className="overflow-x-auto">
+                    <table className="w-full text-left border-collapse text-sm">
+                        <thead className="bg-slate-800/50 text-slate-300 text-xs uppercase tracking-wider">
+                            <tr>
+                                <th className="px-4 py-3 font-medium">Nombre</th>
+                                <th className="px-4 py-3 font-medium">Contacto</th>
+                                <th className="px-4 py-3 font-medium">Departamento</th>
+                                <th className="px-4 py-3 font-medium text-right">Sueldo / Tipo</th>
+                                <th className="px-4 py-3 font-medium text-center">Estado</th>
+                                <th className="px-4 py-3 font-medium text-right">Acciones</th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-slate-800">
+                            {filteredEmployees.length === 0 ? (
+                                <tr>
+                                    <td colSpan={6} className="px-4 py-8 text-center text-slate-500">
+                                        No se encontraron empleados.
+                                    </td>
+                                </tr>
+                            ) : (
+                                filteredEmployees.map((emp) => (
+                                    <tr key={emp.id} className="hover:bg-slate-800/50 transition-colors">
+                                        <td className="px-4 py-3">
+                                            <div className="font-medium text-slate-200">{emp.name}</div>
+                                            {emp.defaultShiftEnd && (
+                                                <div className="text-xs text-slate-500 mt-0.5">
+                                                    Fin de turno: {emp.defaultShiftEnd}
+                                                </div>
+                                            )}
+                                        </td>
+                                        <td className="px-4 py-3">
+                                            <div className="text-slate-300">{emp.email || '—'}</div>
+                                            <div className="text-xs text-slate-500">{emp.phone || ''}</div>
+                                        </td>
+                                        <td className="px-4 py-3 text-slate-300">{emp.department || '—'}</td>
+                                        <td className="px-4 py-3 text-right">
+                                            {emp.salaryAmount ? (
+                                                <>
+                                                    <div className="font-medium">
+                                                        {new Intl.NumberFormat('es-PY', { style: 'currency', currency: 'PYG', maximumFractionDigits: 0 }).format(emp.salaryAmount)}
+                                                    </div>
+                                                    <div className="text-xs text-slate-500">
+                                                        {emp.salaryType === 'MONTHLY' ? 'Mensual' : emp.salaryType === 'WEEKLY' ? 'Semanal' : 'Diario'}
+                                                    </div>
+                                                </>
+                                            ) : (
+                                                <span className="text-slate-500">—</span>
+                                            )}
+                                        </td>
+                                        <td className="px-4 py-3 text-center">
+                                            <span className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${emp.isActive ? 'bg-green-500/10 text-green-400' : 'bg-red-500/10 text-red-400'
+                                                }`}>
+                                                {emp.isActive ? 'Activo' : 'Inactivo'}
+                                            </span>
+                                        </td>
+                                        <td className="px-4 py-3 text-right">
+                                            <div className="flex items-center justify-end gap-2">
+                                                <button
+                                                    onClick={() => navigate(`/main/hr/employees/${emp.id}`)}
+                                                    className="text-slate-400 hover:text-white p-1 rounded"
+                                                    title="Editar"
+                                                >
+                                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                                                    </svg>
+                                                </button>
+                                                <button
+                                                    onClick={() => {
+                                                        if (confirm(`¿Estás seguro que deseas ${emp.isActive ? 'INACTIVAR' : 'ACTIVAR'} a ${emp.name}?`)) {
+                                                            toggleStatus.mutate(emp.id)
+                                                        }
+                                                    }}
+                                                    disabled={toggleStatus.isPending}
+                                                    className={`${emp.isActive ? 'text-orange-400 hover:text-orange-300' : 'text-green-400 hover:text-green-300'} p-1 rounded disabled:opacity-50`}
+                                                    title={emp.isActive ? 'Inactivar' : 'Activar'}
+                                                >
+                                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        {emp.isActive ? (
+                                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                                                        ) : (
+                                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                                        )}
+                                                    </svg>
+                                                </button>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                ))
+                            )}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/modules/hr/pages/PayrollPage.tsx
+++ b/src/modules/hr/pages/PayrollPage.tsx
@@ -1,0 +1,374 @@
+import { useQuery, useMutation } from '@tanstack/react-query'
+import { useState } from 'react'
+import { listEmployees } from '../api/employeeApi'
+import { payrollApi } from '../api/payrollApi'
+import type { PayrollPreviewResponse, EmployeePayment } from '../api/payrollApi'
+import { formatCurrency } from '@/shared/utils/format'
+import { useCurrentOrganization } from '@/shared/hooks/useCurrentOrganization'
+import { PayrollReceiptPrint } from '../components/PayrollReceiptPrint'
+
+export function PayrollPage() {
+    const [activeTab, setActiveTab] = useState<'NEW' | 'HISTORY'>('NEW')
+    const [employeeId, setEmployeeId] = useState('')
+    const [startDate, setStartDate] = useState('')
+    const [endDate, setEndDate] = useState('')
+    const [preview, setPreview] = useState<PayrollPreviewResponse | null>(null)
+    const [errorMsg, setErrorMsg] = useState('')
+    const [successMsg, setSuccessMsg] = useState('')
+    const [printPayment, setPrintPayment] = useState<EmployeePayment | null>(null)
+
+    const { logoUrl: orgLogoUrl, ruc: orgRuc, organization } = useCurrentOrganization()
+    const orgName = organization?.name || ''
+
+    const { data: employees = [], isLoading: isLoadingEmployees } = useQuery({
+        queryKey: ['hr-employees'],
+        queryFn: () => listEmployees(),
+    })
+
+    const previewMutation = useMutation({
+        mutationFn: () => payrollApi.getPreview({ employeeId, startDate, endDate }),
+        onSuccess: (data) => {
+            setPreview(data)
+            setErrorMsg('')
+        },
+        onError: (err: any) => {
+            setPreview(null)
+            setErrorMsg(err?.response?.data?.error || err.message || 'Error al calcular la liquidación')
+        }
+    })
+
+    const executeMutation = useMutation({
+        mutationFn: () => payrollApi.execute({ employeeId, startDate, endDate }),
+        onSuccess: () => {
+            setSuccessMsg('Liquidación generada y registrada con éxito')
+            setPreview(null)
+            // Invalidar historial para que se actualice
+        },
+        onError: (err: any) => {
+            setErrorMsg(err?.response?.data?.error || err.message || 'Error al registrar el pago')
+        }
+    })
+
+    const { data: history = [], isLoading: isLoadingHistory } = useQuery({
+        queryKey: ['hr-payroll-history', employeeId],
+        queryFn: () => payrollApi.getHistory(employeeId),
+        enabled: activeTab === 'HISTORY' && !!employeeId,
+    })
+
+    const handlePreview = (e: React.FormEvent) => {
+        e.preventDefault()
+        setSuccessMsg('')
+        if (!employeeId || !startDate || !endDate) {
+            setErrorMsg('Por favor completa todos los campos')
+            return
+        }
+        previewMutation.mutate()
+    }
+
+    const handleExecute = () => {
+        if (!preview) return
+        if (confirm('¿Estás seguro de registrar este pago? Se marcarán los días y vales como pagados y no podrán volverse a liquidar.')) {
+            executeMutation.mutate()
+        }
+    }
+
+    const handlePrint = (payment: EmployeePayment) => {
+        setPrintPayment(payment)
+        setTimeout(() => {
+            window.print()
+        }, 100)
+    }
+
+    const selectedEmployeeObj = employees.find(e => e.id === employeeId)
+
+    return (
+        <div className="p-4 md:p-6 max-w-5xl mx-auto space-y-6">
+            {/* Header del módulo */}
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 print:hidden">
+                <div>
+                    <h1 className="text-2xl font-bold">Liquidación de Salarios</h1>
+                    <p className="text-slate-400 text-sm">Calcula y registra los pagos de salario por periodo</p>
+                </div>
+                <div className="flex bg-slate-900 rounded-lg p-1 border border-slate-800">
+                    <button
+                        onClick={() => setActiveTab('NEW')}
+                        className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${activeTab === 'NEW' ? 'bg-blue-600 text-white shadow' : 'text-slate-400 hover:text-white hover:bg-slate-800'}`}
+                    >
+                        Nueva Liquidación
+                    </button>
+                    <button
+                        onClick={() => setActiveTab('HISTORY')}
+                        className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${activeTab === 'HISTORY' ? 'bg-blue-600 text-white shadow' : 'text-slate-400 hover:text-white hover:bg-slate-800'}`}
+                    >
+                        Historial
+                    </button>
+                </div>
+            </div>
+
+            <div className="print:hidden">
+                {activeTab === 'NEW' && (
+                    <div className="bg-slate-900 border border-slate-800 rounded-xl p-6">
+                        <form onSubmit={handlePreview} className="gap-4 flex flex-col md:flex-row items-end">
+                            <div className="w-full md:w-1/3">
+                                <label className="block text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">
+                                    Empleado
+                                </label>
+                                <select
+                                    required
+                                    value={employeeId}
+                                    onChange={(e) => {
+                                        setEmployeeId(e.target.value)
+                                        setPreview(null) // Reset preview al cambiar de empleado
+                                    }}
+                                    className="w-full bg-slate-950 border border-slate-800 rounded px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500"
+                                >
+                                    <option value="">Seleccione un empleado...</option>
+                                    {employees.filter(e => e.isActive).map(e => (
+                                        <option key={e.id} value={e.id}>{e.firstName} {e.lastName}</option>
+                                    ))}
+                                </select>
+                            </div>
+
+                            <div className="w-full md:w-1/4">
+                                <label className="block text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">
+                                    Fecha Inicial
+                                </label>
+                                <input
+                                    type="date"
+                                    required
+                                    value={startDate}
+                                    onChange={(e) => {
+                                        setStartDate(e.target.value)
+                                        setPreview(null)
+                                    }}
+                                    className="w-full bg-slate-950 border border-slate-800 rounded px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500"
+                                />
+                            </div>
+
+                            <div className="w-full md:w-1/4">
+                                <label className="block text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">
+                                    Fecha Final
+                                </label>
+                                <input
+                                    type="date"
+                                    required
+                                    value={endDate}
+                                    onChange={(e) => {
+                                        setEndDate(e.target.value)
+                                        setPreview(null)
+                                    }}
+                                    min={startDate}
+                                    className="w-full bg-slate-950 border border-slate-800 rounded px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500"
+                                />
+                            </div>
+
+                            <div className="w-full md:w-auto">
+                                <button
+                                    type="submit"
+                                    disabled={previewMutation.isPending || isLoadingEmployees}
+                                    className="w-full bg-blue-600 hover:bg-blue-500 text-white px-6 py-2 rounded font-medium disabled:opacity-50 transition-colors text-sm h-10 whitespace-nowrap"
+                                >
+                                    {previewMutation.isPending ? 'Calculando...' : 'Calcular Liquidación'}
+                                </button>
+                            </div>
+                        </form>
+
+                        {errorMsg && (
+                            <div className="mt-6 p-4 bg-red-500/10 border border-red-500/50 rounded-lg text-red-400 text-sm">
+                                {errorMsg}
+                            </div>
+                        )}
+                        {successMsg && (
+                            <div className="mt-6 p-4 bg-green-500/10 border border-green-500/50 rounded-lg text-green-400 text-sm">
+                                {successMsg}
+                            </div>
+                        )}
+
+                        {preview && (
+                            <div className="mt-8 border border-slate-800 rounded-lg overflow-hidden">
+                                <div className="bg-slate-950 p-4 border-b border-slate-800 flex justify-between items-center">
+                                    <h3 className="font-medium text-lg text-white">Vista Previa de Liquidación</h3>
+                                    <span className="text-xs bg-slate-800 text-slate-300 px-2 py-1 rounded">Rango: {preview.period.startDate} al {preview.period.endDate}</span>
+                                </div>
+
+                                <div className="p-6 grid grid-cols-1 md:grid-cols-2 gap-8 bg-slate-900">
+                                    {/* Detalles de Días y Extras */}
+                                    <div className="space-y-6">
+                                        <div>
+                                            <h4 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-3">Detalle Asistencia</h4>
+                                            <div className="space-y-2">
+                                                <div className="flex justify-between text-sm">
+                                                    <span className="text-slate-400">Total días trabajados a pagar:</span>
+                                                    <span className="font-medium text-white">{preview.summary.totalDaysWorked} días</span>
+                                                </div>
+                                                <div className="flex justify-between text-sm">
+                                                    <span className="text-slate-400">Total horas extras:</span>
+                                                    <span className="font-medium text-white">{preview.summary.totalOvertimeHours} hrs</span>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <div>
+                                            <h4 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-3">Vales / Adelantos en el Periodo</h4>
+                                            {preview.summary.advancesAmount > 0 ? (
+                                                <div className="space-y-2">
+                                                    <div className="flex justify-between text-sm text-red-400">
+                                                        <span>Total a descontar:</span>
+                                                        <span className="font-medium">{formatCurrency(preview.summary.advancesAmount)}</span>
+                                                    </div>
+                                                    <p className="text-xs text-slate-500">
+                                                        (Se incluyen {preview.daysIncluded.filter(d => d.advance > 0).length + preview.orphanAdvances.length} vales no pagados)
+                                                    </p>
+                                                </div>
+                                            ) : (
+                                                <p className="text-sm text-slate-500">No hay adelantos pendientes a descontar en este periodo.</p>
+                                            )}
+                                        </div>
+                                    </div>
+
+                                    {/* Totales y Resumen Financiero */}
+                                    <div className="space-y-6 md:border-l border-slate-800 md:pl-8">
+                                        <div>
+                                            <h4 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-3">Resumen de Liquidación</h4>
+
+                                            <div className="space-y-3">
+                                                <div className="flex justify-between items-center text-sm">
+                                                    <span className="text-slate-400">Salario Base (<span className="text-xs">{preview.employee.salaryType}</span>)</span>
+                                                    <span className="text-slate-300">{formatCurrency(preview.employee.salaryAmount)}</span>
+                                                </div>
+
+                                                <div className="flex justify-between items-center text-sm">
+                                                    <span className="text-slate-400">Cálculo Base ({preview.summary.totalDaysWorked} días x {formatCurrency(preview.employee.dailyRate)})</span>
+                                                    <span className="font-medium text-white">{formatCurrency(preview.summary.baseAmount)}</span>
+                                                </div>
+
+                                                <div className="flex justify-between items-center text-sm">
+                                                    <span className="text-slate-400">Horas Extras ({preview.summary.totalOvertimeHours} hrs)</span>
+                                                    <span className="font-medium text-emerald-400">+{formatCurrency(preview.summary.overtimeAmount)}</span>
+                                                </div>
+
+                                                {preview.summary.advancesAmount > 0 && (
+                                                    <div className="flex justify-between items-center text-sm">
+                                                        <span className="text-slate-400">Adelantos / Vales</span>
+                                                        <span className="font-medium text-red-400">-{formatCurrency(preview.summary.advancesAmount)}</span>
+                                                    </div>
+                                                )}
+
+                                                <div className="pt-4 mt-2 border-t border-slate-800">
+                                                    <div className="flex justify-between items-center mb-1">
+                                                        <span className="text-sm font-bold text-slate-300">TOTAL A PAGAR</span>
+                                                        <span className="text-2xl font-bold text-white tracking-tight">
+                                                            {formatCurrency(preview.summary.totalAmount)}
+                                                        </span>
+                                                    </div>
+                                                    <p className="text-right text-xs text-emerald-500 font-medium tracking-wide">(Neto)</p>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <div className="pt-4">
+                                            <button
+                                                onClick={handleExecute}
+                                                disabled={executeMutation.isPending || preview.summary.totalAmount === 0 && preview.summary.totalDaysWorked === 0}
+                                                className="w-full bg-emerald-600 hover:bg-emerald-500 text-white px-6 py-3 rounded-lg font-bold shadow-lg shadow-emerald-500/20 disabled:opacity-50 disabled:shadow-none transition-all"
+                                            >
+                                                {executeMutation.isPending ? 'Registrando...' : 'Confirmar y Guardar Pago'}
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                )}
+
+                {activeTab === 'HISTORY' && (
+                    <div className="bg-slate-900 border border-slate-800 rounded-xl p-6 space-y-6">
+                        <div className="w-full md:w-1/3">
+                            <label className="block text-xs font-medium text-slate-400 uppercase tracking-wider mb-2">
+                                Seleccionar Empleado
+                            </label>
+                            <select
+                                value={employeeId}
+                                onChange={(e) => setEmployeeId(e.target.value)}
+                                className="w-full bg-slate-950 border border-slate-800 rounded px-3 py-2 text-sm text-slate-200 focus:outline-none focus:border-blue-500"
+                            >
+                                <option value="">Seleccione un empleado...</option>
+                                {employees.map(e => (
+                                    <option key={e.id} value={e.id}>{e.firstName} {e.lastName}</option>
+                                ))}
+                            </select>
+                        </div>
+
+                        {employeeId && (
+                            isLoadingHistory ? (
+                                <div className="text-slate-400 text-sm py-4">Cargando historial...</div>
+                            ) : history.length === 0 ? (
+                                <div className="text-slate-500 text-sm py-8 text-center border-t border-slate-800">
+                                    No hay liquidaciones registradas para este empleado.
+                                </div>
+                            ) : (
+                                <div className="overflow-x-auto border border-slate-800 rounded-lg">
+                                    <table className="w-full text-left text-sm text-slate-300">
+                                        <thead className="bg-slate-950/50 text-slate-400 uppercase text-xs">
+                                            <tr>
+                                                <th className="px-4 py-3 font-medium">Fecha de Pago</th>
+                                                <th className="px-4 py-3 font-medium">Periodo Pagado</th>
+                                                <th className="px-4 py-3 font-medium text-right">Días</th>
+                                                <th className="px-4 py-3 font-medium text-right">Hrs Extras</th>
+                                                <th className="px-4 py-3 font-medium text-right">Adelantos</th>
+                                                <th className="px-4 py-3 font-medium text-right">Total Pagado</th>
+                                                <th className="px-4 py-3 font-medium text-center">Acción</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody className="divide-y divide-slate-800/50">
+                                            {history.map((payment) => (
+                                                <tr key={payment.id} className="hover:bg-slate-800/20 transition-colors">
+                                                    <td className="px-4 py-3">
+                                                        {new Date(payment.paymentDate).toLocaleDateString()}
+                                                    </td>
+                                                    <td className="px-4 py-3 text-slate-400">
+                                                        {new Date(payment.startDate).toLocaleDateString()} - {new Date(payment.endDate).toLocaleDateString()}
+                                                    </td>
+                                                    <td className="px-4 py-3 text-right">{payment.totalDaysWorked}</td>
+                                                    <td className="px-4 py-3 text-right">{payment.totalOvertimeHours}</td>
+                                                    <td className="px-4 py-3 text-right text-red-400">
+                                                        {Number(payment.advancesAmount) > 0 ? `-${formatCurrency(Number(payment.advancesAmount))}` : '-'}
+                                                    </td>
+                                                    <td className="px-4 py-3 text-right font-medium text-white">
+                                                        {formatCurrency(Number(payment.totalAmount))}
+                                                    </td>
+                                                    <td className="px-4 py-3 text-center">
+                                                        <button
+                                                            onClick={() => handlePrint(payment)}
+                                                            className="text-xs text-blue-400 hover:text-blue-300 underline"
+                                                        >
+                                                            Imprimir
+                                                        </button>
+                                                    </td>
+                                                </tr>
+                                            ))}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            )
+                        )}
+                    </div>
+                )}
+            </div>
+
+            {/* Print View Container (Hidden in screen, block in print) */}
+            <div className="hidden print:block fixed inset-0 bg-white z-[9999]">
+                {printPayment && selectedEmployeeObj && (
+                    <PayrollReceiptPrint
+                        payment={printPayment}
+                        employee={selectedEmployeeObj}
+                        orgLogoUrl={orgLogoUrl!}
+                        orgRuc={orgRuc!}
+                        orgName={orgName!}
+                    />
+                )}
+            </div>
+        </div>
+    )
+}

--- a/src/modules/products/components/ProductForm.tsx
+++ b/src/modules/products/components/ProductForm.tsx
@@ -7,7 +7,6 @@ import { ImageUploader } from '@/shared/ui/image-uploader'
 import { getProductImageUploadUrl } from '@/services/files'
 import { useProductTemplates } from '../hooks/useProducts'
 import type { ProductTemplate } from '@/shared/types/domain'
-
 export interface ProductFormValues extends CreateProductInput { }
 
 export interface ProductFormProps {
@@ -84,7 +83,7 @@ export function ProductForm(props: ProductFormProps): JSX.Element {
     barcode: z.string().optional(),
     imageUrl: z.string().optional(),
     templateId: z.string().nullable().optional(),
-    metadata: z.record(z.any()).optional()
+    metadata: z.record(z.string(), z.any()).optional()
   })
 
   useEffect(() => {
@@ -188,7 +187,7 @@ export function ProductForm(props: ProductFormProps): JSX.Element {
                 disabled={pending}
               >
                 <option value="">Estándar</option>
-                {templates?.map(t => (
+                {templates?.map((t: ProductTemplate) => (
                   <option key={t.id} value={t.id}>{t.name}</option>
                 ))}
               </select>
@@ -426,7 +425,7 @@ export function ProductForm(props: ProductFormProps): JSX.Element {
               <h3 className="font-medium text-slate-700">Detalles de {selectedTemplate.name}</h3>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {Object.entries(selectedTemplate.attributes).map(([key, attr]) => (
+              {Object.entries(selectedTemplate.attributes || {}).map(([key, attr]: [string, any]) => (
                 <div key={key} className={attr.type === 'text' && !attr.options ? 'md:col-span-2' : ''}>
                   <label className="block text-sm font-medium text-slate-700 mb-1">
                     {attr.label} {attr.required && <span className="text-red-500">*</span>}
@@ -440,7 +439,7 @@ export function ProductForm(props: ProductFormProps): JSX.Element {
                       required={attr.required}
                     >
                       <option value="">Seleccionar...</option>
-                      {attr.options.map(opt => (
+                      {attr.options.map((opt: any) => (
                         <option key={opt} value={opt}>{opt}</option>
                       ))}
                     </select>


### PR DESCRIPTION
Introduce employee management and payroll features and add half-day ('medio-dia') support across the HR calendar.

What's included:
- New APIs: src/modules/hr/api/employeeApi.ts and src/modules/hr/api/payrollApi.ts (list/create/update/toggle employee, payroll preview/execute/history).
- New pages/components: Employees list and form pages (EmployeesListPage, EmployeeFormPage), PayrollPage route, and a printable PayrollReceiptPrint component.
- Calendar and model updates: extended Employee and schedule types to include salary fields and isActive; added 'MEDIO_DIA' / 'medio-dia' everywhere (calendar API, hooks, DayCell, CalendarPage mappings and UI). CalendarPage also includes various UI/validation and UX fixes.
- Navigation and module registration: added HR "Personal" and "Liquidaciones" nav links in main layout and hr module routes/nav.
- Misc: removed global anchor style from index.css and small formatting/cleanup changes.

These changes add full CRUD-ish employee flows and payroll preview/execute plumbing and ensure the calendar UI and API understand a half-day day type.